### PR TITLE
Fix mouseover text re-disabling and deprecated WidgetID usage

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Mouseover Text Disabler
 author=Jbleezy
-support=https://github.com/carldibert/runelite-plugins/tree/mouseover-text-disabler
+support=https://github.com/Jbleezy/runelite-plugins/tree/mouseover-text-disabler
 description=Disables the mouseover text
 tags=mouseover,mouse,over,text,disabler
 plugins=com.mouseovertextdisabler.MouseoverTextDisablerPlugin

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,7 @@
 displayName=Mouseover Text Disabler
 author=Jbleezy
-support=https://github.com/Jbleezy/runelite-plugins/tree/mouseover-text-disabler
+support=https://github.com/carldibert/runelite-plugins/tree/mouseover-text-disabler
 description=Disables the mouseover text
 tags=mouseover,mouse,over,text,disabler
 plugins=com.mouseovertextdisabler.MouseoverTextDisablerPlugin
+build=standard

--- a/src/main/java/com/mouseovertextdisabler/MouseoverTextDisablerPlugin.java
+++ b/src/main/java/com/mouseovertextdisabler/MouseoverTextDisablerPlugin.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.widgets.WidgetID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -78,14 +78,14 @@ public class MouseoverTextDisablerPlugin extends Plugin
 	// doesn't work if client is on click to play screen
 	@Subscribe
 	public void onWidgetLoaded(net.runelite.api.events.WidgetLoaded widgetLoaded) {
-		if (widgetLoaded.getGroupId() == WidgetID.LOGIN_CLICK_TO_PLAY_GROUP_ID) {
+		if (widgetLoaded.getGroupId() == InterfaceID.WELCOME_SCREEN) {
 			loginClickToPlayLoaded = true;
 		}
 	}
 
 	@Subscribe
 	public void onWidgetClosed(net.runelite.api.events.WidgetClosed widgetClosed) {
-		if (widgetClosed.getGroupId() == WidgetID.LOGIN_CLICK_TO_PLAY_GROUP_ID) {
+		if (widgetClosed.getGroupId() == InterfaceID.WELCOME_SCREEN) {
 			loginClickToPlayLoaded = false;
 		}
 

--- a/src/main/java/com/mouseovertextdisabler/MouseoverTextDisablerPlugin.java
+++ b/src/main/java/com/mouseovertextdisabler/MouseoverTextDisablerPlugin.java
@@ -88,6 +88,8 @@ public class MouseoverTextDisablerPlugin extends Plugin
 		if (widgetClosed.getGroupId() == WidgetID.LOGIN_CLICK_TO_PLAY_GROUP_ID) {
 			loginClickToPlayLoaded = false;
 		}
+
+		mouseoverTextDisabled = false;
 	}
 
 	@Provides


### PR DESCRIPTION
## Summary
- Re-disable mouseover text when any widget closes, not just specific ones
- Replace deprecated `WidgetID` with `InterfaceID`
- Add required `build=standard` entry to `runelite-plugin.properties`

## Test plan
- [ ] Load plugin in RuneLite client and confirm mouseover text stays disabled after closing various widgets (bank, inventory, etc.)
- [ ] Confirm no deprecation warnings from `WidgetID` usage